### PR TITLE
No datasource available so switch to build  block

### DIFF
--- a/bounce-script.sh
+++ b/bounce-script.sh
@@ -11,65 +11,66 @@ if [ -z "$RSA_PUB" ]; then
 fi
 
 if [ -d /etc/custom ]; then
-   sudo rm -rf /etc/custom
+   rm -rf /etc/custom
 fi
 
-sudo mkdir /etc/custom
-sudo chmod 0700 /etc/custom
+mkdir /etc/custom
+chmod 0700 /etc/custom
 
 echo "Loading private key"
-echo "$RSA_KEY" | base64 --decode | sudo tee /etc/custom/ssh_host_rsa_key > /dev/null
-sudo chown root:root /etc/custom/ssh_host_rsa_key
-sudo chmod 400 /etc/custom/ssh_host_rsa_key
+echo "$RSA_KEY" | base64 --decode > /etc/custom/ssh_host_rsa_key
+chown root:root /etc/custom/ssh_host_rsa_key
+chmod 400 /etc/custom/ssh_host_rsa_key
 
 echo "Loading public key"
-echo "$RSA_PUB" | base64 --decode | sudo tee /etc/custom/ssh_host_rsa_key.pub > /dev/null
-sudo chown root:root /etc/custom/ssh_host_rsa_key.pub
-sudo chmod 600 /etc/custom/ssh_host_rsa_key.pub
+echo "$RSA_PUB" | base64 --decode > /etc/custom/ssh_host_rsa_key.pub
+chown root:root /etc/custom/ssh_host_rsa_key.pub
+chmod 600 /etc/custom/ssh_host_rsa_key.pub
 
 echo "Building jail directory"
-sudo mkdir -p /home/jail/dev
+mkdir -p /home/jail/dev
 cd /home/jail/dev
-sudo mknod -m 666 null c 1 3
-sudo chown root:root /home/jail
-sudo chmod 0755 /home/jail
+mknod -m 666 null c 1 3
+chown root:root /home/jail
+chmod 0755 /home/jail
+cd -
 
 echo "Loading configuration file"
-echo -e "HostKey /etc/custom/ssh_host_rsa_key\nChrootDirectory /home/jail" | sudo tee /etc/ssh/sshd_config.d/custom.conf > /dev/null
+echo -e "HostKey /etc/custom/ssh_host_rsa_key\nChrootDirectory /home/jail" > /etc/ssh/sshd_config.d/custom.conf
 
-if ! sudo test -f /etc/custom/ssh_host_rsa_key; then
+if ! test -f /etc/custom/ssh_host_rsa_key; then
    echo "private key /etc/custom/ssh_host_rsa_key was not correctly written"
    exit 1
 fi
-if ! sudo test -s /etc/custom/ssh_host_rsa_key; then
+if ! test -s /etc/custom/ssh_host_rsa_key; then
    echo "private key /etc/custom/ssh_host_rsa_key is empty"
    exit 1
 fi
 echo "Private key successfully loaded"
 
-if ! sudo test -f /etc/custom/ssh_host_rsa_key.pub; then
+if ! test -f /etc/custom/ssh_host_rsa_key.pub; then
    echo "Public key /etc/custom/ssh_host_rsa_key.pub was not correctly written"
    exit 1
 fi
-if ! sudo test -s /etc/custom/ssh_host_rsa_key.pub; then
+if ! test -s /etc/custom/ssh_host_rsa_key.pub; then
    echo "Public key /etc/custom/ssh_host_rsa_key.pub is empty"
    exit 1
 fi
 echo "Public key successfully loaded"
 
-if ! sudo test -f /etc/ssh/sshd_config.d/custom.conf; then
+if ! test -f /etc/ssh/sshd_config.d/custom.conf; then
    echo "Configuration file /etc/ssh/sshd_config.d/custom.conf was not correctly written"
    exit 1
 fi
-if ! sudo test -s /etc/ssh/sshd_config.d/custom.conf; then
+if ! test -s /etc/ssh/sshd_config.d/custom.conf; then
    echo "Configuration file /etc/ssh/sshd_config.d/custom.conf is empty"
    exit 1
 fi
 echo "Configuration file successfully loaded"
 
 echo "Installing simple Nginx server"
-sudo DEBIAN_FRONTEND=noninteractive apt-get --quiet update >/dev/null
-sudo DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install nginx >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get --quiet update >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install nginx >/dev/null
 
 if ! systemctl is-active nginx > /dev/null; then
    echo "Nginx service is not active."
@@ -84,20 +85,20 @@ fi
 echo "Nginx server is correctly responding."
 
 # Disable APT sources
-sudo apt-get --quiet clean >/dev/null
-sudo rm -rf /etc/apt/sources.list /etc/apt/sources.list.d/
+apt-get --quiet clean >/dev/null
+rm -rf /etc/apt/sources.list /etc/apt/sources.list.d/
 
 # Disable APT auto updates
-echo -ne "APT::Periodic::Update-Package-Lists \"0\";\nAPT::Periodic::Unattended-Upgrade \"0\";" | sudo tee /etc/apt/apt.conf.d/20auto-upgrades > /dev/null
-if ! sudo test -f /etc/apt/apt.conf.d/20auto-upgrades; then
+echo -ne "APT::Periodic::Update-Package-Lists \"0\";\nAPT::Periodic::Unattended-Upgrade \"0\";" > /etc/apt/apt.conf.d/20auto-upgrades
+if ! test -f /etc/apt/apt.conf.d/20auto-upgrades; then
    echo "Configuration file /etc/apt/apt.conf.d/20auto-upgrades was not correctly written."
    exit 1
 fi
-if ! sudo test -s /etc/apt/apt.conf.d/20auto-upgrades; then
+if ! test -s /etc/apt/apt.conf.d/20auto-upgrades; then
    echo "Configuration file /etc/apt/apt.conf.d/20auto-upgrades is empty."
    exit 1
 fi
 echo "APT auto updates succesfully disabled."
 
-echo "Build succesful"
+echo -ne "\nBuild succesful\n"
 exit 0

--- a/main.pkr.hcl
+++ b/main.pkr.hcl
@@ -1,4 +1,5 @@
 packer {
+  required_version = ">= 1.8.0"
   required_plugins {
     googlecompute = {
       version = "~> 1.0.10"
@@ -31,6 +32,7 @@ source "googlecompute" "custom" {
 }
 
 build {
+  name    = join("-", [var.workspace.name, "build", var.machine.source_image_family])
   sources = ["sources.googlecompute.custom"]
 
   provisioner "shell" {
@@ -38,6 +40,8 @@ build {
       "RSA_PUB=${var.machine.rsa_keystore.public}",
       "RSA_KEY=${var.machine.rsa_keystore.private}"
     ]
-    script = "./bounce-script.sh"
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    valid_exit_codes = [0]
+    script           = "./bounce-script.sh"
   }
 }


### PR DESCRIPTION
Re-configured build block with an **execute_command** that runs as root.